### PR TITLE
[6] Add conversion tracking data attribute to tracked elements

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -60,6 +60,10 @@ sampleRUM.drain('convert', (cevent, cvalueThunk, element, listenTo = []) => {
     if (Array.isArray(elements) || elements instanceof NodeList) {
       elements.forEach((e) => registerConversionListener(e, listenTo, cevent, cvalueThunk));
     } else {
+      // add data attribute to elements tracked in preview
+      if (window.location.hostname === 'localhost' || window.location.hostname.endsWith('.hlx.page')) {
+        element.dataset.conversionTracking = true;
+      }
       listenTo.forEach((eventName) => element.addEventListener(
         eventName,
         (e) => trackConversion(e.target),


### PR DESCRIPTION
## Description

In preview only, add an attribute data-conversion-tracking = true to the html elements that are identified as eligible to raise conversion events.
This would help other systems, such as Omnivore, to identify which elements are defined for tracking by practitioners in Franklin

## Related Issue
#6 
SITES-15583

## Motivation and Context
Facilitate the integration of Omnivore overlay

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
