### PR TITLE
chore(update): update to support latest version of boilerplate

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,11 @@ This method has 2 modes:
 * conversion tracking mode: If the method is called with empty `listenTo` it will track a conversion using as conversion name the `cevent` and/or `cvalueThunk` as conversion value.
 
 ### Integration with Analytics solutions
+
+:warning: If you want to make use of the hook described below, you must ensure your `lib-franklin.js` is up to date (not older than 23.08.2023) and contains the changes in these 2 commits:
+* https://github.com/adobe/helix-project-boilerplate/commit/871ede401d2d57c8825f8970f3b28cd9de5f27f8
+* https://github.com/adobe/helix-project-boilerplate/commit/fcca39dd4f5fd2aef6852580873ab4b2cce1e2af
+
 In order to track conversions defined in Franklin in Analytics solutions, you can leverage the method `sampleRUM.always.on('convert', (data) => { ... })`\
 This method is invoked by the RUM conversion framework after every call to convert method. The parameter `data` contains the information of the conversion event tracked.
 

--- a/src/index.js
+++ b/src/index.js
@@ -10,13 +10,6 @@
  * governing permissions and limitations under the License.
  */
 const { sampleRUM } = window.hlx.rum;
-// SampleRUM always initialization should happen in lib-franklin
-// we need to initialize it here until the initialization is part of
-// the boilerplate.
-sampleRUM.always = sampleRUM.always || [];
-sampleRUM.always.on = (chkpnt, fn) => {
-  sampleRUM.always[chkpnt] = fn;
-};
 
 /**
 * Registers the 'convert' function to `sampleRUM` which sends
@@ -45,10 +38,6 @@ sampleRUM.drain('convert', (cevent, cvalueThunk, element, listenTo = []) => {
 
       const data = { source: cevent, target: cvalue, element: celement };
       sampleRUM('convert', data);
-      // Following if statement must be removed once always mechanism is present in the boilerplate
-      if (sampleRUM.always && sampleRUM.always.convert) {
-        sampleRUM.always.convert(data);
-      }
     } catch (e) {
       // eslint-disable-next-line no-console
       console.log('error reading experiments', e);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adapt to latest boilerplate

## Related Issue
#8 

## Motivation and Context
Latest code in boilerplate already initializes `sampleRUM.always` mechanism and invokes `sampleRUM.always.on`. 
RUM Conversion tracking should not do the same for projects already using that version of the boilerplate 


## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
